### PR TITLE
security: restrict CORS allowed origins for preflight requests

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -22,7 +22,9 @@ provider:
     httpApi: true
   httpApi:
     # metrics: true # Enable if you need
-    cors: true
+    cors:
+      allowedOrigins:
+        - https://example.com
 
 functions:
   app:


### PR DESCRIPTION
This is a recommendation to configure Serverless/HTTP API to restrict CORS origins on preflight requests. Feel free to close if it's out of scope for this boilerplate.

Thanks!

---

Restricts allowed origins for cross-origin preflight requests. Only `allowedOrigins` is overridden; other options will fall back to Serverless defaults [1].

[1] https://www.serverless.com/framework/docs/providers/aws/events/http-api#cors-setup